### PR TITLE
Fix logic for creating installments for a reservation

### DIFF
--- a/src/components/installments/Installments.tsx
+++ b/src/components/installments/Installments.tsx
@@ -22,11 +22,18 @@ interface IProps {
 
 const Installments = ({ customer }: IProps): JSX.Element => {
   const { t } = useTranslation();
+
+  // Filter reservations:
+  // 1. All reservations that have saved installments
+  // Or
+  // 2. Reservation's state is not in a state "REVIEW" and reservation's queue position is 1
   const visibleReservations =
     customer.apartment_reservations?.filter(
       (reservation) =>
-        !!reservation.apartment_installments?.length || reservation.state === ApartmentReservationStates.RESERVED
+        !!reservation.apartment_installments?.length ||
+        (reservation.state !== ApartmentReservationStates.REVIEW && reservation.queue_position === 1)
     ) || [];
+
   const reservationsByProject = groupReservationsByProject(visibleReservations);
 
   if (!reservationsByProject.length) {
@@ -48,6 +55,7 @@ const Installments = ({ customer }: IProps): JSX.Element => {
                 apartment={getReservationApartmentData(reservation)}
                 project={getReservationProjectData(reservation)}
                 reservationId={reservation.id}
+                isCanceled={reservation.state === ApartmentReservationStates.CANCELED}
               />
             </div>
           ))}

--- a/src/components/installments/InstallmentsItem.module.scss
+++ b/src/components/installments/InstallmentsItem.module.scss
@@ -136,3 +136,7 @@
     }
   }
 }
+
+.disabled {
+  color: var(--color-black-40);
+}

--- a/src/components/installments/InstallmentsItem.tsx
+++ b/src/components/installments/InstallmentsItem.tsx
@@ -20,6 +20,7 @@ interface IProps {
   apartment: Apartment;
   project: Project;
   reservationId: ApartmentReservation['id'];
+  isCanceled: boolean;
 }
 
 export const renderApartmentDetails = (apartment: Apartment) => (
@@ -63,7 +64,7 @@ export const renderApartmentPrice = (project: Project, apartment: Apartment) => 
   );
 };
 
-const InstallmentsItem = ({ apartment, project, reservationId }: IProps): JSX.Element | null => {
+const InstallmentsItem = ({ apartment, project, reservationId, isCanceled }: IProps): JSX.Element | null => {
   const { t } = useTranslation();
   const openFormDialogButtonRef = useRef(null);
   const [isFormDialogOpen, setIsFormDialogOpen] = useState(false);
@@ -212,7 +213,7 @@ const InstallmentsItem = ({ apartment, project, reservationId }: IProps): JSX.El
   return (
     <>
       <div className={styles.apartmentRow}>
-        <div className={styles.apartmentRowLeft}>
+        <div className={cx(styles.apartmentRowLeft, isCanceled && styles.disabled)}>
           {renderApartmentDetails(apartment)}
           <div>{renderApartmentPrice(project, apartment)}</div>
         </div>

--- a/src/components/reservations/CustomerReservationRow.tsx
+++ b/src/components/reservations/CustomerReservationRow.tsx
@@ -30,6 +30,8 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
   const apartment = getReservationApartmentData(reservation);
   const project = getReservationProjectData(reservation);
   const isCanceled = reservation.state === ApartmentReservationStates.CANCELED;
+  const isInReview = reservation.state === ApartmentReservationStates.REVIEW;
+  const firstInQueue = reservation.queue_position === 1;
 
   const preContractDownloading = () => setIsLoadingContract(true);
   const postContractDownloading = () => setIsLoadingContract(false);
@@ -122,7 +124,7 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
           )}
         </div>
       </div>
-      {!isCanceled && reservation.queue_position === 1 && (
+      {firstInQueue && (
         <div className={styles.buttons}>
           <Button
             variant="secondary"
@@ -139,14 +141,18 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
           >
             {t(`${T_PATH}.createOffer`)}
           </Button>
-          <Button variant="secondary" size="small" onClick={download} disabled={isLoadingContract}>
-            {reservation.project_ownership_type.toLowerCase() === 'haso'
-              ? t(`${T_PATH}.createContract`)
-              : t(`${T_PATH}.createDeedOfSale`)}
-          </Button>
-          <a href={fileUrl} download={fileName} className="hiddenFromScreen" ref={fileRef}>
-            {t(`${T_PATH}.download`)}
-          </a>
+          {!isInReview && (
+            <>
+              <Button variant="secondary" size="small" onClick={download} disabled={isLoadingContract}>
+                {reservation.project_ownership_type.toLowerCase() === 'haso'
+                  ? t(`${T_PATH}.createContract`)
+                  : t(`${T_PATH}.createDeedOfSale`)}
+              </Button>
+              <a href={fileUrl} download={fileName} className="hiddenFromScreen" ref={fileRef}>
+                {t(`${T_PATH}.download`)}
+              </a>
+            </>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Previously we checked if the reservation is in a state "reserved". This does not work in e.g. the case being that offer has been accepted and the salesperson wants to create installments for the customer. Then the reservation is not in the reserved state and creating installments is not possible. Change this logic to allow creating installments when the reservation is not in the "review" state and the reservation is first in the queue.

Also, show dimmed text for installment rows where the reservation is canceled but installments have already been saved.

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/7901266/169026062-237d46e3-b84e-43e7-83da-e25f4b9bd697.png">

Add similar functionality for downloading contracts. Disallow downloading the contracts if the reservation is in review state.