### PR TITLE
User auth updates and cleaning of data on logout - ASU-1599

### DIFF
--- a/src/auth/oidc-react.ts
+++ b/src/auth/oidc-react.ts
@@ -342,6 +342,7 @@ export function createOidcClient(): Client {
 
   clientFunctions.addListener(ClientEvent.UNAUTHORIZED, () => {
     userSessionValidityPoller.stop();
+    sessionStorage.clear(); // Clear session storage on logout
   });
 
   clientFunctions.addListener(ClientEvent.TOKEN_EXPIRING, () => {

--- a/src/components/auth/WithIdleProvider.tsx
+++ b/src/components/auth/WithIdleProvider.tsx
@@ -1,18 +1,20 @@
 import React, { FC } from 'react';
 import { IdleTimerProvider } from 'react-idle-timer';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { getClient } from '../../auth/oidc-react';
 import {
   hideAuthSessionExpiringModal,
   showAuthSessionExpiringModal,
 } from '../../redux/features/authSessionExpiringModalSlice';
+import { RootState } from '../../redux/store';
 
 export const TIMEOUT_MINUTES = process.env.REACT_APP_IDLE_TIMEOUT_MINUTES || '15';
 
 const IdleTimer: FC<unknown> = ({ children }) => {
   const client = getClient();
   const dispatch = useDispatch();
+  const isModalOpen = useSelector((state: RootState) => state.authSessionExpiringModal.isOpened);
 
   const onPrompt = (): void => {
     dispatch(showAuthSessionExpiringModal());
@@ -23,15 +25,23 @@ const IdleTimer: FC<unknown> = ({ children }) => {
     client.logout();
   };
 
+  const onActive = (): void => {
+    if (isModalOpen) {
+      dispatch(hideAuthSessionExpiringModal());
+    }
+  };
+
   return (
     <IdleTimerProvider
       timeout={1000 * 60 * parseInt(TIMEOUT_MINUTES)}
       onPrompt={onPrompt}
       onIdle={onIdle}
+      onActive={onActive}
       promptTimeout={1000 * 60}
       name="att-sales-ui-idle-timer"
       startOnMount
       crossTab
+      syncTimers={1000}
     >
       {children}
     </IdleTimerProvider>

--- a/src/redux/StoreProvider.tsx
+++ b/src/redux/StoreProvider.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, FC } from 'react';
 import { Provider } from 'react-redux';
 
+import { api } from './services/api';
 import { ClientEvent, ClientErrorObject, User } from '../auth';
 import { authorized, connected, errorThrown, initializing, tokenExpired, unauthorized } from './features/authSlice';
 import { store } from './store';
@@ -22,6 +23,7 @@ const StoreProvider: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
     });
     client.addListener(ClientEvent.UNAUTHORIZED, () => {
       store.dispatch(unauthorized());
+      store.dispatch(api.util.resetApiState());
     });
     client.addListener(ClientEvent.TOKEN_EXPIRED, () => {
       store.dispatch(tokenExpired());


### PR DESCRIPTION
* Fix cross tab issue from idle provider
  * Add the `onActive` function to hide the inactivity modal from other tabs
when the user is again active on any of the tabs
* Reset API Redux state when the user logs out
  * (Clears cache)
* Clear session storage when the user logs out