### PR TITLE
Fix OfferForm validation issue

### DIFF
--- a/src/components/offer/OfferForm.tsx
+++ b/src/components/offer/OfferForm.tsx
@@ -173,6 +173,7 @@ const OfferForm = ({ formId, handleFormCallback, offer, ownershipType, reservati
                   render={({ field }) => (
                     <RadioButton
                       id="state_pending"
+                      name="state"
                       checked={field.value === OfferState.PENDING}
                       disabled={!!offer.concluded_at}
                       label={getRadioLabel(OfferState.PENDING)}
@@ -188,6 +189,7 @@ const OfferForm = ({ formId, handleFormCallback, offer, ownershipType, reservati
                   render={({ field }) => (
                     <RadioButton
                       id="state_accepted"
+                      name="state"
                       checked={field.value === OfferState.ACCEPTED}
                       disabled={!!offer.concluded_at}
                       label={getRadioLabel(OfferState.ACCEPTED)}
@@ -203,6 +205,7 @@ const OfferForm = ({ formId, handleFormCallback, offer, ownershipType, reservati
                   render={({ field }) => (
                     <RadioButton
                       id="state_rejected"
+                      name="state"
                       checked={field.value === OfferState.REJECTED}
                       disabled={!!offer.concluded_at}
                       label={getRadioLabel(OfferState.REJECTED)}


### PR DESCRIPTION
The issue doesn't affect chrome. With Firefox the offer form fails to validate the radio selection due to missing name making it impossible to save any changes. 
![image](https://user-images.githubusercontent.com/437576/203267059-f17fdca1-7831-4138-b207-9249b6dee886.png)
