### PR TITLE
Flexible installments handling

### DIFF
--- a/src/components/installments/ProjectInstallments.tsx
+++ b/src/components/installments/ProjectInstallments.tsx
@@ -133,12 +133,16 @@ const ProjectInstallments = ({
     };
 
     // Map input field data to use correct format for the API
-    const apiData = nonEmptyRows.map((row, index) => {
-      // Define using either of amount (€) or percentage values
-      const sumFields =
-        row.unit === unitOptions.UNIT_AS_PERCENTAGE
-          ? { percentage: getFormattedSum(row.sum, true), percentage_specifier: row.percentage_specifier }
-          : { amount: getFormattedSum(row.sum, false) };
+    const apiData = nonEmptyRows.map((row) => {
+      // Define using either of amount (€) or percentage values -- or neither if flexible
+      let sumFields;
+      if (row.percentage_specifier === HitasInstallmentPercentageSpecifiers.SalesPriceFlexible) {
+        sumFields = { percentage_specifier: row.percentage_specifier };
+      } else if (row.unit === unitOptions.UNIT_AS_PERCENTAGE) {
+        sumFields = { percentage: getFormattedSum(row.sum, true), percentage_specifier: row.percentage_specifier };
+      } else {
+        sumFields = { amount: getFormattedSum(row.sum, false) };
+      }
 
       // Use date format of YYYY-MM-DD if there's a valid date
       const formattedDate =
@@ -217,10 +221,11 @@ const ProjectInstallments = ({
   // };
 
   const isPercentageRow = (index: number) => {
-    if (inputFields[index].unit === unitOptions.UNIT_AS_PERCENTAGE) {
-      return true;
-    }
-    return false;
+    return inputFields[index].unit === unitOptions.UNIT_AS_PERCENTAGE;
+  };
+
+  const isFlexibleInstallmentRow = (index: number) => {
+    return inputFields[index].percentage_specifier === HitasInstallmentPercentageSpecifiers.SalesPriceFlexible;
   };
 
   const InstallmentTypeOptions = () => {
@@ -298,27 +303,31 @@ const ProjectInstallments = ({
             />
           </td>
           <td>
-            <TextInput
-              type="number"
-              pattern="[0-9]+([\.,][0-9]+)?"
-              id={`sum-${index}`}
-              name="sum"
-              label=""
-              className={styles.input}
-              value={input.sum}
-              onChange={(event) => handleInputChange(index, event)}
-            />
+            {!isFlexibleInstallmentRow(index) && (
+              <TextInput
+                type="number"
+                pattern="[0-9]+([\.,][0-9]+)?"
+                id={`sum-${index}`}
+                name="sum"
+                label=""
+                className={styles.input}
+                value={input.sum}
+                onChange={(event) => handleInputChange(index, event)}
+              />
+            )}
           </td>
           <td>
-            <Select
-              id={`unit-${index}`}
-              placeholder={t(`${T_PATH}.select`)}
-              label=""
-              className={styles.select}
-              options={InstallmentUnitOptions}
-              value={InstallmentUnitOptions.find((value) => value.selectValue === input.unit) || emptySelectOption}
-              onChange={(value: SelectOption) => handleSelectChange(index, value)}
-            />
+            {!isFlexibleInstallmentRow(index) && (
+              <Select
+                id={`unit-${index}`}
+                placeholder={t(`${T_PATH}.select`)}
+                label=""
+                className={styles.select}
+                options={InstallmentUnitOptions}
+                value={InstallmentUnitOptions.find((value) => value.selectValue === input.unit) || emptySelectOption}
+                onChange={(value: SelectOption) => handleSelectChange(index, value)}
+              />
+            )}
           </td>
           <td>
             <Select

--- a/src/components/installments/ProjectInstallments.tsx
+++ b/src/components/installments/ProjectInstallments.tsx
@@ -303,36 +303,38 @@ const ProjectInstallments = ({
             />
           </td>
           <td>
-            {!isFlexibleInstallmentRow(index) && (
-              <TextInput
-                type="number"
-                pattern="[0-9]+([\.,][0-9]+)?"
-                id={`sum-${index}`}
-                name="sum"
-                label=""
-                className={styles.input}
-                value={input.sum}
-                onChange={(event) => handleInputChange(index, event)}
-              />
-            )}
+            <TextInput
+              type="number"
+              pattern="[0-9]+([\.,][0-9]+)?"
+              id={`sum-${index}`}
+              name="sum"
+              label=""
+              className={styles.input}
+              value={!isFlexibleInstallmentRow(index) ? input.sum : ''}
+              onChange={(event) => handleInputChange(index, event)}
+              disabled={isFlexibleInstallmentRow(index)}
+            />
           </td>
           <td>
-            {!isFlexibleInstallmentRow(index) && (
-              <Select
-                id={`unit-${index}`}
-                placeholder={t(`${T_PATH}.select`)}
-                label=""
-                className={styles.select}
-                options={InstallmentUnitOptions}
-                value={InstallmentUnitOptions.find((value) => value.selectValue === input.unit) || emptySelectOption}
-                onChange={(value: SelectOption) => handleSelectChange(index, value)}
-              />
-            )}
+            <Select
+              id={`unit-${index}`}
+              placeholder={!isFlexibleInstallmentRow(index) ? t(`${T_PATH}.select`) : ''}
+              label=""
+              className={styles.select}
+              options={InstallmentUnitOptions}
+              value={
+                isFlexibleInstallmentRow(index)
+                  ? emptySelectOption
+                  : InstallmentUnitOptions.find((value) => value.selectValue === input.unit) || emptySelectOption
+              }
+              onChange={(value: SelectOption) => handleSelectChange(index, value)}
+              disabled={isFlexibleInstallmentRow(index)}
+            />
           </td>
           <td>
             <Select
               id={`unitSpecifier-${index}`}
-              placeholder={t(`${T_PATH}.select`)}
+              placeholder={isPercentageRow(index) ? t(`${T_PATH}.select`) : ''}
               label=""
               className={styles.select}
               options={InstallmentPercentageSpecifierOptions()}


### PR DESCRIPTION
Depends on https://github.com/City-of-Helsinki/apartment-application-service/pull/316

Just my opinion, but I didn't like disabling the dropdown as the text "Valitse" still visible. Could probably consider doing the same thing for the "type €" specifier too to keep appearance consistent? Unless there's a good reason to keep those cells visible.. 

![image](https://user-images.githubusercontent.com/437576/203268139-68a62d21-c535-4034-8ece-2e56698affad.png)
