### PR TITLE
ASU-1690 | Take right of residence old batch into account

### DIFF
--- a/src/components/apartment/ApartmentRow.tsx
+++ b/src/components/apartment/ApartmentRow.tsx
@@ -31,6 +31,7 @@ import { showReservationAddModal } from '../../redux/features/reservationAddModa
 import { showReservationCancelModal } from '../../redux/features/reservationCancelModalSlice';
 import { showReservationEditModal } from '../../redux/features/reservationEditModalSlice';
 import { useGetApartmentReservationsQuery } from '../../redux/services/api';
+import { getRightOfResidenceText } from '../../utils/getRightOfResidenceText';
 
 import styles from './ApartmentRow.module.scss';
 
@@ -126,7 +127,7 @@ const ApartmentRow = ({ apartment, ownershipType, isLotteryCompleted, project }:
 
   const renderHasoNumberOrFamilyIcon = (reservation: ApartmentReservationWithCustomer) => {
     if (ownershipType === 'haso') {
-      return reservation.right_of_residence;
+      return getRightOfResidenceText(reservation);
     }
     if (reservation.has_children) {
       return <IconGroup />;

--- a/src/components/customers/CustomerInfo.tsx
+++ b/src/components/customers/CustomerInfo.tsx
@@ -5,6 +5,7 @@ import { Checkbox, Notification } from 'hds-react';
 
 import formatDateTime from '../../utils/formatDateTime';
 import { Customer } from '../../types';
+import { getRightOfResidenceText } from '../../utils/getRightOfResidenceText';
 
 import styles from './CustomerInfo.module.scss';
 
@@ -131,9 +132,7 @@ const CustomerInfo = ({ customer }: IProps): JSX.Element => {
           </InfoItem>
         </div>
         <div className={styles.extraInfoRowItem}>
-          <InfoItem label={t(`${T_PATH}.hasoNumber`)}>
-            {customer.right_of_residence ? customer.right_of_residence.toString() : '-'}
-          </InfoItem>
+          <InfoItem label={t(`${T_PATH}.hasoNumber`)}>{getRightOfResidenceText(customer)}</InfoItem>
         </div>
       </div>
 

--- a/src/components/offer/OfferModal.tsx
+++ b/src/components/offer/OfferModal.tsx
@@ -18,6 +18,7 @@ import { toast } from '../common/toast/ToastManager';
 import { useCreateOfferMutation, useGetOfferByIdQuery, useUpdateOfferByIdMutation } from '../../redux/services/api';
 
 import styles from './OfferModal.module.scss';
+import { getRightOfResidenceText } from '../../utils/getRightOfResidenceText';
 
 const T_PATH = 'components.offer.OfferModal';
 
@@ -292,7 +293,7 @@ const OfferModal = (): JSX.Element | null => {
           </td>
           {project.ownership_type.toLowerCase() === 'haso' ? (
             <>
-              <td>{reservation.right_of_residence || '-'}</td>
+              <td>{getRightOfResidenceText(reservation)}</td>
               <td>{renderBooleanTextualValue(reservation.is_age_over_55)}</td>
               <td>{renderBooleanTextualValue(reservation.is_right_of_occupancy_housing_changer)}</td>
             </>

--- a/src/components/reservations/CustomerReservationRow.tsx
+++ b/src/components/reservations/CustomerReservationRow.tsx
@@ -21,6 +21,7 @@ import { useDownloadFile } from '../../utils/useDownloadFile';
 import { useFileDownloadApi } from '../../utils/useFileDownloadApi';
 
 import styles from './CustomerReservationRow.module.scss';
+import { getRightOfResidenceText } from '../../utils/getRightOfResidenceText';
 
 const T_PATH = 'components.reservations.CustomerReservationRow';
 
@@ -179,7 +180,7 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
                   {t(`${T_PATH}.rightOfResidence`)}
                   <span className={styles.asterisk}>&nbsp;*</span>
                 </th>
-                <td>{reservation.right_of_residence ? reservation.right_of_residence : '-'}</td>
+                <td>{getRightOfResidenceText(customer)}</td>
               </tr>
               <tr>
                 <th>
@@ -291,7 +292,7 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
               </div>
               {isOwnershipTypeHaso && (
                 <div>
-                  {t(`${T_PATH}.hasoNumber`)}: {reservation.right_of_residence}
+                  {t(`${T_PATH}.hasoNumber`)}:{' ' + getRightOfResidenceText(customer)}
                 </div>
               )}
             </>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -429,6 +429,7 @@
   "pages.customers.AddEditCustomer.postalCode": "Postal code",
   "pages.customers.AddEditCustomer.required": "Required",
   "pages.customers.AddEditCustomer.rightOfResidence": "Aso number",
+  "pages.customers.AddEditCustomer.rightOfResidenceIsOldBatch": "Aso number issued on 31.8.2023 or before",
   "pages.customers.AddEditCustomer.save": "Save",
   "pages.customers.AddEditCustomer.saving": "Saving",
   "pages.customers.AddEditCustomer.secondaryCustomer": "Co-Applicant",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -475,6 +475,7 @@
   "utils.getOfferText.expired": "Offer expired",
   "utils.getProjectState.archived": "Archived",
   "utils.getProjectState.unpublished": "Unpublished",
+  "utils.getRightOfResidenceText.old": "old",
   "utils.renderBooleanTextualValue.no": "No",
   "utils.renderBooleanTextualValue.unknown": "Unknown",
   "utils.renderBooleanTextualValue.yes": "Yes",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -475,6 +475,7 @@
   "utils.getOfferText.expired": "Tarjous vanhentunut",
   "utils.getProjectState.archived": "Arkistoitu",
   "utils.getProjectState.unpublished": "Julkaisematon",
+  "utils.getRightOfResidenceText.old": "vanha",
   "utils.renderBooleanTextualValue.no": "Ei",
   "utils.renderBooleanTextualValue.unknown": "Ei tiedossa",
   "utils.renderBooleanTextualValue.yes": "Kyllä",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -429,6 +429,7 @@
   "pages.customers.AddEditCustomer.postalCode": "Postinumero",
   "pages.customers.AddEditCustomer.required": "Vaadittu kenttä",
   "pages.customers.AddEditCustomer.rightOfResidence": "Aso-numero",
+  "pages.customers.AddEditCustomer.rightOfResidenceIsOldBatch": "Aso-numero myönnetty 31.8.2023 tai aiemmin",
   "pages.customers.AddEditCustomer.save": "Tallenna",
   "pages.customers.AddEditCustomer.saving": "Tallennetaan",
   "pages.customers.AddEditCustomer.secondaryCustomer": "Kanssahakija",

--- a/src/pages/customers/AddEditCustomer.tsx
+++ b/src/pages/customers/AddEditCustomer.tsx
@@ -92,6 +92,7 @@ const AddEditCustomer = ({ isEditMode }: IProps) => {
         .number()
         .nullable()
         .transform((val, originalVal) => (originalVal === '' ? null : val)),
+      right_of_residence_is_old_batch: yup.boolean().nullable(),
       primary_profile: profileSchema().required(),
       secondary_profile: yup
         .object()
@@ -142,6 +143,10 @@ const AddEditCustomer = ({ isEditMode }: IProps) => {
     // Set secondary profile as null if 'has_secondary_profile' checkbox is unchecked
     if (!formData.has_secondary_profile) {
       formData.secondary_profile = null;
+    }
+
+    if (!formData.right_of_residence) {
+      formData.right_of_residence_is_old_batch = null;
     }
 
     const apiData = omit(formData, 'created_at', 'has_secondary_profile');
@@ -713,6 +718,22 @@ const AddEditCustomer = ({ isEditMode }: IProps) => {
                 errorText={errors.right_of_residence?.message}
                 style={{ width: '50%' }}
                 {...register('right_of_residence')}
+              />
+            </div>
+            <div>
+              <Controller
+                name="right_of_residence_is_old_batch"
+                control={control}
+                render={({ field }) => (
+                  <Checkbox
+                    id="rightOfResidenceIsOldBatch"
+                    label={t(`${T_PATH}.rightOfResidenceIsOldBatch`)}
+                    checked={Boolean(field.value)}
+                    errorText={errors.right_of_residence_is_old_batch?.message}
+                    style={{ marginRight: 'var(--spacing-l)' }}
+                    {...register('right_of_residence_is_old_batch')}
+                  />
+                )}
               />
             </div>
           </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,7 @@ export type Customer = {
   last_contact_date?: string | null;
   primary_profile: CustomerProfile;
   right_of_residence?: number | null;
+  right_of_residence_is_old_batch?: boolean | null;
   secondary_profile?: CustomerProfile | null;
   apartment_reservations?: CustomerReservation[] | null;
 };
@@ -252,6 +253,7 @@ export type ApartmentReservationWithCustomer = ApartmentReservation & {
   customer: ApartmentReservationCustomer;
   has_children: Customer['has_children'];
   right_of_residence: Customer['right_of_residence'];
+  right_of_residence_is_old_batch: Customer['right_of_residence_is_old_batch'];
   has_hitas_ownership: Customer['has_hitas_ownership'];
   is_age_over_55: Customer['is_age_over_55'];
   is_right_of_occupancy_housing_changer: Customer['is_right_of_occupancy_housing_changer'];
@@ -306,6 +308,7 @@ export type CustomerReservation = {
   project_uuid: Project['uuid'];
   queue_position?: number | null;
   right_of_residence: Customer['right_of_residence'];
+  right_of_residence_is_old_batch: Customer['right_of_residence_is_old_batch'];
   state: `${ApartmentReservationStates}`;
   state_change_events?: ReservationStateChangeEvent[] | null;
 };
@@ -335,6 +338,7 @@ export type AddEditCustomerFormFields = {
   last_contact_date: string | null;
   primary_profile: Omit<CustomerProfile, 'id'>;
   right_of_residence: number | null;
+  right_of_residence_is_old_batch: boolean | null;
   secondary_profile: Omit<CustomerProfile, 'id'> | null;
 };
 
@@ -386,6 +390,7 @@ export type OfferModalReservationData = Pick<
   | 'id'
   | 'offer'
   | 'right_of_residence'
+  | 'right_of_residence_is_old_batch'
   | 'has_hitas_ownership'
   | 'is_age_over_55'
   | 'is_right_of_occupancy_housing_changer'

--- a/src/utils/getRightOfResidenceText.test.ts
+++ b/src/utils/getRightOfResidenceText.test.ts
@@ -1,0 +1,34 @@
+import { ApartmentReservationWithCustomer } from '../types';
+import { getRightOfResidenceText } from './getRightOfResidenceText';
+
+describe('getRightOfResidenceText', () => {
+  it('should render old batch numbers correctly', () => {
+    const apartmentReservation = {
+      right_of_residence: 12345,
+      right_of_residence_is_old_batch: true,
+    } as ApartmentReservationWithCustomer;
+    const rightOfResidenceText = getRightOfResidenceText(apartmentReservation);
+
+    expect(rightOfResidenceText).toEqual('12345 (vanha)');
+  });
+
+  it('should render new batch numbers correctly', () => {
+    const apartmentReservation = {
+      right_of_residence: 12345,
+      right_of_residence_is_old_batch: false,
+    } as ApartmentReservationWithCustomer;
+    const rightOfResidenceText = getRightOfResidenceText(apartmentReservation);
+
+    expect(rightOfResidenceText).toEqual('12345');
+  });
+
+  it('should render non-haso instances correctly', () => {
+    const apartmentReservation = {
+      right_of_residence: null,
+      right_of_residence_is_old_batch: null,
+    } as ApartmentReservationWithCustomer;
+    const rightOfResidenceText = getRightOfResidenceText(apartmentReservation);
+
+    expect(rightOfResidenceText).toEqual('-');
+  });
+});

--- a/src/utils/getRightOfResidenceText.ts
+++ b/src/utils/getRightOfResidenceText.ts
@@ -1,0 +1,16 @@
+import i18n from '../i18n/i18n';
+import { ApartmentReservationWithCustomer, Customer, OfferModalReservationData } from '../types';
+
+const T_PATH = 'utils.getRightOfResidenceText';
+
+export const getRightOfResidenceText = (
+  instance: ApartmentReservationWithCustomer | OfferModalReservationData | Customer
+): string => {
+  if (!instance.right_of_residence) {
+    return '-';
+  }
+  return (
+    instance.right_of_residence.toString() +
+    (instance.right_of_residence_is_old_batch ? ` (${i18n.t(T_PATH + '.old')})` : '')
+  );
+};


### PR DESCRIPTION
There are two batches of ASO numbers determined on the day the number is given (31.8.2023 or later). The support for those was added to the backend in https://github.com/City-of-Helsinki/apartment-application-service/pull/362. This PR adds support for the frontend:

- Added postfix (old) to all displayed old batch right of residence numbers
- Added checkbox to customer add/edit form where the batch can be set
<hr>

<img width="1530" alt="Screenshot 2023-09-30 at 21 54 12" src="https://github.com/City-of-Helsinki/att-sales-ui/assets/1314604/b0597aee-157a-49a8-8b2a-682e978905aa">
Apartment reservation list
<hr>

<img width="1431" alt="Screenshot 2023-09-30 at 22 18 13" src="https://github.com/City-of-Helsinki/att-sales-ui/assets/1314604/35cac7cf-df4e-42b1-a9de-ef5633d7a16b">
Customer info
<hr>

<img width="1501" alt="Screenshot 2023-09-30 at 21 55 30" src="https://github.com/City-of-Helsinki/att-sales-ui/assets/1314604/9b8b42b5-ed0f-434c-a8ee-850f6ca5c5c4">
Customer add/edit form
