### PR TITLE
ASU-1699 | Fix long customer name overflow in project page apartment row

### DIFF
--- a/src/components/apartment/ApartmentRow.module.scss
+++ b/src/components/apartment/ApartmentRow.module.scss
@@ -37,6 +37,7 @@
   display: block;
   padding-top: 0;
   padding-bottom: 0;
+  min-width: 0;
 }
 
 .smallToggleButton {
@@ -129,6 +130,7 @@
   flex-grow: 1;
   flex-shrink: 1;
   align-items: flex-start;
+  min-width: 0;
 
   &.open {
     display: none;


### PR DESCRIPTION
<img width="1417" alt="Screenshot 2023-10-02 at 22 37 02" src="https://github.com/City-of-Helsinki/att-sales-ui/assets/1314604/9b99185d-c035-4885-aab9-a6a3616c2b9b">
Before
<hr>
<img width="1415" alt="Screenshot 2023-10-02 at 22 37 20" src="https://github.com/City-of-Helsinki/att-sales-ui/assets/1314604/7b6059bb-009b-4d53-8d17-c9e39f01960c">
After
