### PR TITLE
Fix download contract file naming

### DIFF
--- a/src/components/reservations/CustomerReservationRow.tsx
+++ b/src/components/reservations/CustomerReservationRow.tsx
@@ -56,10 +56,20 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
   };
 
   const getContractFileName = (): string => {
-    const projectName = reservation.project_housing_company.replace(/\s/g, '-').toLocaleLowerCase();
-    const apartmentNumber = reservation.apartment_number.replace(/\s/g, '').toLocaleLowerCase();
+    const projectName = reservation.project_housing_company;
+    const apartmentNumber = reservation.apartment_number;
     let prefix = '';
 
+    const slugify = (text: string): string => {
+      return text
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9 ]/g, '')
+        .replace(/\s+/g, '-');
+    };
+  
     if (isOwnershipTypeHaso) {
       prefix = 'sopimus';
     } else {
@@ -67,7 +77,8 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
     }
 
     // Example output: "kauppakirja_as-oy-project-x_a01_2022-01-01.pdf"
-    return `${prefix}${JSON.stringify(projectName + '_' + apartmentNumber)}${new Date().toJSON().slice(0, 10)}.pdf`;
+     
+    return `${prefix}${slugify(projectName + ' ' + apartmentNumber)}-${new Date().toJSON().slice(0, 10)}.pdf`;
   };
 
   const contractApiUrl = `/apartment_reservations/${reservation.id}/contract/`;


### PR DESCRIPTION
When trying to download a contract and the project name had a comma or another character, some browsers would give error.
Fix this by removing strange characters when creating a filename using a simple slugify function.