### PR TITLE
Remove strange characters from filenames

### DIFF
--- a/src/components/reservations/CustomerReservationRow.tsx
+++ b/src/components/reservations/CustomerReservationRow.tsx
@@ -16,6 +16,7 @@ import { getReservationApartmentData, getReservationProjectData } from '../../ut
 import { renderBooleanTextualValue } from '../../utils/renderBooleanTextualValue';
 import { showOfferModal } from '../../redux/features/offerModalSlice';
 import { showReservationCancelModal } from '../../redux/features/reservationCancelModalSlice';
+import { slugify } from '../../utils/slugifyString';
 import { toast } from '../common/toast/ToastManager';
 import { useDownloadFile } from '../../utils/useDownloadFile';
 import { useFileDownloadApi } from '../../utils/useFileDownloadApi';
@@ -58,17 +59,7 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
   const getContractFileName = (): string => {
     const projectName = reservation.project_housing_company;
     const apartmentNumber = reservation.apartment_number;
-    let prefix = '';
-
-    const slugify = (text: string): string => {
-      return text
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9 ]/g, '')
-        .replace(/\s+/g, '-');
-    };
+    let prefix = ''; 
   
     if (isOwnershipTypeHaso) {
       prefix = 'sopimus';
@@ -77,8 +68,8 @@ const CustomerReservationRow = ({ customer, reservation }: IProps): JSX.Element 
     }
 
     // Example output: "kauppakirja_as-oy-project-x_a01_2022-01-01.pdf"
-     
-    return `${prefix}${slugify(projectName + ' ' + apartmentNumber)}-${new Date().toJSON().slice(0, 10)}.pdf`;
+  
+    return `${prefix}-${slugify(projectName + ' ' + apartmentNumber)}-${new Date().toJSON().slice(0, 10)}.pdf`;
   };
 
   const contractApiUrl = `/apartment_reservations/${reservation.id}/contract/`;

--- a/src/components/reservations/ReservationReleasePDF.tsx
+++ b/src/components/reservations/ReservationReleasePDF.tsx
@@ -6,6 +6,7 @@ import { useGetCustomerByIdQuery } from '../../redux/services/api';
 import { ApartmentReservation, Customer } from '../../types';
 import { useDownloadFile } from '../../utils/useDownloadFile';
 import { useFileDownloadApi } from '../../utils/useFileDownloadApi';
+import { slugify } from '../../utils/slugifyString';
 import { toast } from '../common/toast/ToastManager';
 
 const T_PATH = 'components.reservations.ReservationReleasePDF';
@@ -40,8 +41,8 @@ const ReservationReleasePDF = ({ reservationId, customerId, disabled = false }: 
 
     const projectName = reservation?.project_housing_company.replace(/\s/g, '-').toLocaleLowerCase();
     const apartmentNumber = reservation?.apartment_number.replace(/\s/g, '').toLocaleLowerCase();
-    const identifier = projectName && apartmentNumber ? JSON.stringify(projectName + '_' + apartmentNumber) : '';
-
+    let  identifier = projectName && apartmentNumber ? JSON.stringify(projectName + '_' + apartmentNumber) : '';
+    identifier = slugify(identifier);
     // Example output: "luovutushintalaskelma_as-oy-project-x_a01_2022-01-01.pdf" (on Chrome)
     // Example output: "luovutushintalaskelma as-oy-project-x a01_2022-01-01.pdf" (on FF :-)
     return `luovutushintalaskelma${identifier}${new Date().toJSON().slice(0, 10)}.pdf`;

--- a/src/utils/slugifyString.ts
+++ b/src/utils/slugifyString.ts
@@ -1,0 +1,10 @@
+export const slugify = (text: string): string => {
+    return text
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '')  // Remove all non-word characters except spaces and hyphens
+      .replace(/[\s_-]+/g, '-')  // Replace spaces, underscores, and hyphens with a single hyphen
+      .replace(/^-+|-+$/g, '');  // Remove leading and trailing hyphens
+  };


### PR DESCRIPTION
When downloading filenames, when they have a
strange character the browswer will get errors,
no allowing contracts do be downloaded or other PDFs.

Fix this by using a slugify function to sanitize filenames, ensuring they are formatted into friendly names that are compatible with browser downloads